### PR TITLE
Fix inconsistent-apply-result errors for tsb_oidc and tsb_team

### DIFF
--- a/cmd/gen-provider/emit.go
+++ b/cmd/gen-provider/emit.go
@@ -8,12 +8,16 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
 
 	j "github.com/dave/jennifer/jen"
+	"google.golang.org/genproto/googleapis/api/annotations"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
 )
 
 // Framework import paths used by the generated code.
@@ -503,4 +507,23 @@ var createOnlyMessages = map[string]bool{
 // isCreateOnly reports whether a field carries create-only secrets.
 func isCreateOnly(fd protoreflect.FieldDescriptor) bool {
 	return isMessageKind(fd) && createOnlyMessages[string(fd.Message().FullName())]
+}
+
+// isInputOnly reports whether a field is annotated `google.api.field_behavior =
+// INPUT_ONLY`: the server accepts it on write but never returns it in responses
+// (e.g. OIDC.secret, a client secret TSB stores outside its database and never
+// echoes back). Such fields must not be overwritten by flatten — the model
+// already holds the correct value, either from the plan (create/update) or the
+// prior state (read) — or every apply would report a produced-inconsistent-state
+// error as the server's always-empty response blanks out the configured value.
+func isInputOnly(fd protoreflect.FieldDescriptor) bool {
+	opts, ok := fd.Options().(*descriptorpb.FieldOptions)
+	if !ok {
+		return false
+	}
+	behaviors, ok := proto.GetExtension(opts, annotations.E_FieldBehavior).([]annotations.FieldBehavior)
+	if !ok {
+		return false
+	}
+	return slices.Contains(behaviors, annotations.FieldBehavior_INPUT_ONLY)
 }

--- a/cmd/gen-provider/emit_conv.go
+++ b/cmd/gen-provider/emit_conv.go
@@ -265,6 +265,12 @@ func (g *generator) flattenField(p fieldPlan) ([]j.Code, error) {
 		}, nil
 	}
 
+	// INPUT_ONLY fields are never echoed back by the server; leave the model's
+	// existing value (plan or prior state) untouched instead of overwriting it.
+	if isInputOnly(fd) {
+		return nil, nil
+	}
+
 	switch {
 	case fd.IsMap():
 		if isMessageKind(fd.MapValue()) {

--- a/internal/provider/models_gen.go
+++ b/internal/provider/models_gen.go
@@ -1558,7 +1558,6 @@ func flattenOIDC(ctx context.Context, p *v2.OIDC, m *OIDCModel) diag.Diagnostics
 	} else {
 		m.Config = nil
 	}
-	m.Secret = stringOrNull(p.Secret)
 	return diags
 }
 

--- a/internal/provider/schema_fixup.go
+++ b/internal/provider/schema_fixup.go
@@ -3,13 +3,24 @@
 package provider
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 )
+
+// enumZeroValueDefault is the sentinel a proto enum's zero value renders as
+// (e.g. SourceType_INVALID = 0 -> "INVALID"). protoc-gen-terraform falls back
+// to this name as a Computed attribute's Default whenever the proto field is
+// missing a `+protoc-gen-terraform:enumdefault:N` override tag — it is never a
+// deliberately chosen default. See defaultIsUntrustworthy.
+const enumZeroValueDefault = "INVALID"
 
 // fixupSchema adapts a reused TSB schema (produced by protoc-gen-terraform) so it
 // is valid and well-behaved for the Terraform Plugin Framework at serve time.
 //
-// Two adjustments are made, recursively, to every attribute:
+// Adjustments are made, recursively, to every attribute:
 //
 //  1. Required attributes carrying a Default (the enum StaticString default the
 //     schema generator emits) have the Default dropped — Required+Default is
@@ -28,9 +39,28 @@ import (
 //     made Computed: the generated models back them with plain Go structs, which
 //     cannot represent the "unknown" plan value that Computed introduces. Their
 //     leaf attributes are still fixed up via recursion.
+//
+//  3. Computed-only (not Optional/Required) string attributes whose Default
+//     resolves to the proto enum zero-value sentinel have the Default dropped
+//     in favor of UseStateForUnknown. Such a Default is protoc-gen-terraform's
+//     "no real default configured" fallback, not a value TSB actually persists
+//     (e.g. Team.source_type defaults to "INVALID", but CreateTeam/UpdateTeam
+//     always coerce an unset source type to LOCAL server-side) — keeping it
+//     forces a known planned value that the server's real response then
+//     contradicts, producing "Provider produced inconsistent result after
+//     apply" on every create. Leaving the planned value unknown lets it be
+//     filled in from whatever the server actually returns.
 func fixupSchema(s schema.Schema) schema.Schema {
 	s.Attributes = fixupAttributes(s.Attributes)
 	return s
+}
+
+// defaultIsUntrustworthy reports whether d resolves to the proto enum
+// zero-value sentinel (see enumZeroValueDefault).
+func defaultIsUntrustworthy(d defaults.String) bool {
+	var resp defaults.StringResponse
+	d.DefaultString(context.Background(), defaults.StringRequest{}, &resp)
+	return resp.PlanValue.ValueString() == enumZeroValueDefault
 }
 
 func fixupAttributes(in map[string]schema.Attribute) map[string]schema.Attribute {
@@ -44,10 +74,14 @@ func fixupAttributes(in map[string]schema.Attribute) map[string]schema.Attribute
 func fixupAttribute(attr schema.Attribute) schema.Attribute {
 	switch a := attr.(type) {
 	case schema.StringAttribute:
-		if a.Required {
+		switch {
+		case a.Required:
 			a.Default = nil
-		} else if a.Optional {
+		case a.Optional:
 			a.Computed = true
+		case a.Computed && a.Default != nil && defaultIsUntrustworthy(a.Default):
+			a.Default = nil
+			a.PlanModifiers = append(a.PlanModifiers, stringplanmodifier.UseStateForUnknown())
 		}
 		return a
 	case schema.BoolAttribute:


### PR DESCRIPTION
## Summary
- `tsb_oidc.secret` is proto `INPUT_ONLY` (accepted on write, never echoed back). `flatten<Resource>` was unconditionally overwriting the model with the server's always-empty response for such fields, producing "Provider produced inconsistent result after apply" on every create/update. Fixed generically in `cmd/gen-provider` by detecting `google.api.field_behavior = INPUT_ONLY` and skipping the flatten assignment.
- `tsb_team.source_type` is Computed-only with a `Default` that falls back to the proto enum zero value (`"INVALID"`) because it's missing the upstream `enumdefault` override tag its sibling `User.source_type` has. TSB's `CreateTeam`/`UpdateTeam` always coerce an unset source type to `LOCAL` server-side, so the planned `"INVALID"` never matches the server's real response. Fixed in `internal/provider/schema_fixup.go`: Computed-only string attributes whose Default resolves to the enum zero-value sentinel now drop the Default in favor of `UseStateForUnknown`, so the plan value stays unknown until the server's actual value is known. `User.source_type`'s legitimate `MANUAL` default is untouched.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `make format` (clean diff)
- [x] Ad hoc test confirming `fixupSchema(TeamSchema())` drops the Default + adds `UseStateForUnknown` on `source_type`, while `fixupSchema(UserSchema())` leaves its `MANUAL` default untouched
- [ ] `terraform apply` against a live TSB instance with `tsb_oidc` + `tsb_team` resources (not run here — requires live infra)

🤖 Generated with [Claude Code](https://claude.com/claude-code)